### PR TITLE
Add fixity unparsing for ABTs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "lib/cmlib"]
 	path = lib/cmlib
 	url = git@github.com:standardml/cmlib.git
+[submodule "lib/sml-unparse"]
+	path = lib/sml-unparse
+	url = git@github.com:jonsterling/sml-unparse.git

--- a/abt-parser.cm
+++ b/abt-parser.cm
@@ -6,6 +6,7 @@ is
   $libs/cmlib/cmlib.cm
   $libs/sml-abt/abt.cm
   $libs/sml-parcom-wrapper/parcom.cm
+  $libs/sml-unparse/unparse.cm
   src/parse_operator.sig
   src/parse_abt.sig
   src/parse_abt.fun

--- a/abt-parser.cm
+++ b/abt-parser.cm
@@ -2,11 +2,16 @@ Library
   signature PARSE_OPERATOR
   signature PARSE_ABT
   functor ParseAbt
+  signature UNPARSE_ABT
+  functor UnparseAbt
 is
   $libs/cmlib/cmlib.cm
   $libs/sml-abt/abt.cm
+  $libs/sml-abt/vector-lib/vector-lib.cm
   $libs/sml-parcom-wrapper/parcom.cm
   $libs/sml-unparse/unparse.cm
   src/parse_operator.sig
   src/parse_abt.sig
   src/parse_abt.fun
+  src/unparse_abt.sig
+  src/unparse_abt.fun

--- a/development.cm
+++ b/development.cm
@@ -2,5 +2,7 @@ Library
   signature PARSE_OPERATOR
   signature PARSE_ABT
   functor ParseAbt
+  signature UNPARSE_ABT
+  functor UnparseAbt
 is
   abt-parser.cm (bind:(anchor:libs value:lib))

--- a/src/unparse_abt.fun
+++ b/src/unparse_abt.fun
@@ -1,0 +1,33 @@
+functor UnparseAbt
+  (structure Abt : ABT
+   structure Unparse : UNPARSE) : UNPARSE_ABT =
+struct
+  structure AbtUtil = AbtUtil(Abt) and Unparse = Unparse
+  open AbtUtil Unparse
+  structure V = Variable
+
+  infix 5 $ $$ \ \\
+
+  fun extensibleUnparseAbt inner e =
+    case out e of
+        ` v => atom (V.toString v)
+      | v \ e =>
+        let
+          val vstr =
+            if hasFree (e, v) then
+              Variable.toString v
+            else
+              "_"
+        in
+          atom (vstr ^ "." ^ parens (done (inner e)))
+        end
+      | p $ es =>
+          atom (Operator.toString p ^
+                 (if Vector.length es = 0 then ""
+                   else VectorPretty.toString (parens o done o inner) es))
+
+  fun unparseAbt t =
+    extensibleUnparseAbt unparseAbt t
+
+  val toString = parens o done o unparseAbt
+end

--- a/src/unparse_abt.sig
+++ b/src/unparse_abt.sig
@@ -1,0 +1,8 @@
+signature UNPARSE_ABT =
+sig
+  include ABT_UTIL
+  structure Unparse : UNPARSE
+
+  val extensibleUnparseAbt : (t -> string Unparse.part) -> t -> string Unparse.part
+  val unparseAbt : t -> string Unparse.part
+end


### PR DESCRIPTION
This will allow custom display forms to be pretty printed properly with precedence, fixity, etc.
